### PR TITLE
write less logs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
trying to deal with problem #6, I noticed that in the production mode debug logs are written.

may be better not to write them by default?

P.S. project is cool, I hope there will be a community around it that will develop it